### PR TITLE
Use dict in place of ordereddict in marshal

### DIFF
--- a/flask_restful/__init__.py
+++ b/flask_restful/__init__.py
@@ -618,7 +618,7 @@ def marshal(data, fields, display_null=True):
     >>> mfields = { 'a': fields.Raw }
 
     >>> marshal(data, mfields)
-    OrderedDict([('a', 100)])
+    {'a': 100}
 
     """
 
@@ -636,7 +636,7 @@ def marshal(data, fields, display_null=True):
                                else make(v).output(k, data)
         if display_null or not(tmp is None):
             items.append((k, tmp))
-    return OrderedDict(items)
+    return dict(items)
 
 
 class marshal_with(object):
@@ -650,7 +650,7 @@ class marshal_with(object):
     ...
     ...
     >>> get()
-    OrderedDict([('a', 100)])
+    {'a': 100}
 
     >>> @marshal_with(mfields, envelope='data')
     ... def get():
@@ -658,7 +658,7 @@ class marshal_with(object):
     ...
     ...
     >>> get()
-    OrderedDict([('data', OrderedDict([('a', 100)]))])
+    {'data': {'a': 100}}
 
     see :meth:`flask_restful.marshal`
     """


### PR DESCRIPTION
This aim to fix our problems of memory, it's a complicated but let say
that each ordereddict create at least one cyclic list: a list than
contain itself. The garbage collector of python handle that kind of
thing pretty well, but for performance reason collection of long lived
objects is not done too often. As explained here:
https://github.com/python/cpython/blob/master/Modules/gcmodule.c#L86
collection of old objects is only done when at least 25% of the old
objects has not lived a full collection yet.

On long request, typically isochrone, the ordereddict from the response
live long enough to be considered has old objects, for most fast
requests objects don't live long enough to become "old", so we almost
never trigger a full collection exempt on isochrone request.
So memory don't grow without control, but a lot of the memory allocated
for an isochrone request isn't really released until the next isochrone
request.

Test have been made with an isochrone request on fr-idf with a max
duration of 1H30, memory is measured at the end of the request:

|  | dict | orderedDict |
| --- | --- | --- |
| memory | 180mo | 500mo |
| duration | 12sec | 17sec |
