### PR TITLE
Update boolean types

### DIFF
--- a/flask_restful/types.py
+++ b/flask_restful/types.py
@@ -51,12 +51,17 @@ def natural(value):
 
 def boolean(value):
     """Parse the string "true" or "false" as a boolean (case insensitive)"""
+    if isinstance(value, bool):
+        return value
+
+    if not value:
+        raise ValueError("boolean type must be non-null")
     value = value.lower()
-    if value == 'true':
+    if value in ('true', '1',):
         return True
-    if value == 'false':
+    if value in ('false', '0',):
         return False
-    raise ValueError("Invalid literal for boolean(): {}".format(value))
+    raise ValueError("Invalid literal for boolean(): {0}".format(value))
 
 
 def rfc822(dt):

--- a/flask_restful/types.py
+++ b/flask_restful/types.py
@@ -50,7 +50,12 @@ def natural(value):
 
 
 def boolean(value):
-    """Parse the string "true" or "false" as a boolean (case insensitive)"""
+    """Parse the string ``"true"`` or ``"false"`` as a boolean (case
+    insensitive). Also accepts ``"1"`` and ``"0"`` as ``True``/``False``
+    (respectively). If the input is from the request JSON body, the type is
+    already a native python boolean, and will be passed through without
+    further parsing.
+    """
     if isinstance(value, bool):
         return value
 

--- a/flask_restful/types.py
+++ b/flask_restful/types.py
@@ -59,12 +59,15 @@ def boolean(value):
     if isinstance(value, bool):
         return value
 
+    if isinstance(value, int):
+        return bool(value)
+
     if not value:
         raise ValueError("boolean type must be non-null")
     value = value.lower()
-    if value in ('true', '1',):
+    if value in ('true', '1'):
         return True
-    if value in ('false', '0',):
+    if value in ('false', '0'):
         return False
     raise ValueError("Invalid literal for boolean(): {}".format(value))
 

--- a/flask_restful/types.py
+++ b/flask_restful/types.py
@@ -66,7 +66,7 @@ def boolean(value):
         return True
     if value in ('false', '0',):
         return False
-    raise ValueError("Invalid literal for boolean(): {0}".format(value))
+    raise ValueError("Invalid literal for boolean(): {}".format(value))
 
 
 def rfc822(dt):


### PR DESCRIPTION
In order to use json boolean and check it with falsk_restful the boolean type must be updated.
You could see that it's a copy / past of the new inputs.boolean of flask-restful in the last version (https://github.com/flask-restful/flask-restful/blob/master/flask_restful/inputs.py#L237)
with some upgrade (int to bool)


Related to https://github.com/CanalTP/Chaos/pull/433